### PR TITLE
About dialog can be disabled 

### DIFF
--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/extension/faulttolerance/FaultTolerance.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/extension/faulttolerance/FaultTolerance.java
@@ -11,19 +11,19 @@ import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.VerticalLayout;
 
-import eu.unifiedviews.helpers.dpu.exec.ExecContext;
-import eu.unifiedviews.helpers.dpu.config.ConfigException;
-import eu.unifiedviews.helpers.dpu.config.ConfigHistory;
-import eu.unifiedviews.helpers.dpu.context.Context;
-import eu.unifiedviews.helpers.dpu.context.ContextUtils;
-import eu.unifiedviews.helpers.dpu.vaadin.dialog.AbstractExtensionDialog;
-import eu.unifiedviews.helpers.dpu.vaadin.dialog.Configurable;
 import eu.unifiedviews.dataunit.DataUnitException;
 import eu.unifiedviews.dataunit.MetadataDataUnit;
 import eu.unifiedviews.dpu.DPUContext;
 import eu.unifiedviews.dpu.DPUException;
 import eu.unifiedviews.dpu.config.DPUConfigException;
+import eu.unifiedviews.helpers.dpu.config.ConfigException;
+import eu.unifiedviews.helpers.dpu.config.ConfigHistory;
+import eu.unifiedviews.helpers.dpu.context.Context;
+import eu.unifiedviews.helpers.dpu.context.ContextUtils;
+import eu.unifiedviews.helpers.dpu.exec.ExecContext;
 import eu.unifiedviews.helpers.dpu.extension.Extension;
+import eu.unifiedviews.helpers.dpu.vaadin.dialog.AbstractExtensionDialog;
+import eu.unifiedviews.helpers.dpu.vaadin.dialog.Configurable;
 
 /**
  * Provide possibility to wrap user code. Wrapped code may be re-executed in case of failure and so this
@@ -35,7 +35,7 @@ public class FaultTolerance implements Extension, Configurable<FaultTolerance.Co
 
     public static final String USED_CONFIG_NAME = "addon/faultToleranceWrap";
 
-    public static final String ADDON_NAME = "Fault tolerance";
+    public static final String ADDON_NAME = "dialog.dpu.tab.faulttolerance";
 
     private static final Logger LOG = LoggerFactory.getLogger(FaultTolerance.class);
 
@@ -142,7 +142,7 @@ public class FaultTolerance implements Extension, Configurable<FaultTolerance.Co
             layout.setSpacing(true);
             layout.setMargin(true);
 
-            checkEnabled = new CheckBox("Enable");
+            checkEnabled = new CheckBox(FaultTolerance.this.context.asUserContext().tr("dialog.dpu.faulttolerance.enabled"));
             layout.addComponent(checkEnabled);
 
             final Panel panel = new Panel();
@@ -173,8 +173,7 @@ public class FaultTolerance implements Extension, Configurable<FaultTolerance.Co
 
     private Configuration_V1 config;
 
-    private final ConfigHistory<Configuration_V1> configHistory
-            = ConfigHistory.noHistory(Configuration_V1.class);
+    private final ConfigHistory<Configuration_V1> configHistory = ConfigHistory.noHistory(Configuration_V1.class);
 
     /**
      * Context used by DPU, used to find out cancellation.

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -10,6 +10,7 @@ import java.util.ResourceBundle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.Label;
@@ -20,25 +21,19 @@ import eu.unifiedviews.helpers.dpu.context.UserContext;
 
 /**
  * About page for DPU. Content should be generated based on context.
- *
  * TODO Petr: We should consider localization here too.
  *
  * @author Škoda Petr
  */
 public class AboutTab extends CustomComponent {
 
+    private static final long serialVersionUID = -1097541500977063250L;
+
     private static final Logger LOG = LoggerFactory.getLogger(AboutTab.class);
 
-    private final String BUNDLE_NAME = "build-info";
+    private static final String DPU_ABOUT_TAB_NAME = "dialog.dpu.tab.about";
 
-    private final String HTML_SYSTEM_PROPERTIES = "<b>System properties</b><br>"
-            + "<ul>"
-            + "<li>Build time: %s</li>"
-            + "<li>Git branch: %s</li>"
-            + "<li>Git dirty: %s</li>"
-            + "<li>Git commit: %s</li>"
-            + "</ul>"
-            + "<br/><hr/>";
+    private final String BUNDLE_NAME = "build-info";
 
     private final String HTML_FOOTER = "<br/><hr/>"
             + "Powered by <a href=\"https://github.com/mff-uk\">CUNI helpers</a>.";
@@ -49,7 +44,7 @@ public class AboutTab extends CustomComponent {
 
     @Override
     public String getCaption() {
-        return "About";
+        return DPU_ABOUT_TAB_NAME;
     }
 
     public void buildLayout(DialogContext context) {

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AbstractDialog.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AbstractDialog.java
@@ -28,7 +28,7 @@ import eu.unifiedviews.helpers.dpu.serialization.xml.SerializationXmlFailure;
 public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<MasterConfigObject>
         implements InitializableConfigDialog {
 
-    private static final String ABOUT_DIALOG_PROPERTY = "frontend.dpu.dialog.about.enabled";
+    private static final String ABOUT_DIALOG_PROPERTY = "frontend.dpu.dialog.about.disabled";
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDialog.class);
 
@@ -109,8 +109,8 @@ public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<Master
             }
         }
         // Add AboutTab if not disabled in properties
-        String aboutEnabledProperty = this.context.getDialogContext().getEnvironment().get(ABOUT_DIALOG_PROPERTY);
-        if (aboutEnabledProperty == null || Boolean.getBoolean(aboutEnabledProperty)) {
+        String aboutDisabledProperty = this.context.getDialogContext().getEnvironment().get(ABOUT_DIALOG_PROPERTY);
+        if (aboutDisabledProperty == null || !Boolean.getBoolean(aboutDisabledProperty)) {
             final AboutTab aboutTab = new AboutTab();
             aboutTab.buildLayout(context);
             // FIXME: should be localized

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AbstractDialog.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AbstractDialog.java
@@ -110,7 +110,7 @@ public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<Master
         }
         // Add AboutTab if not disabled in properties
         String aboutDisabledProperty = this.context.getDialogContext().getEnvironment().get(ABOUT_DIALOG_PROPERTY);
-        if (aboutDisabledProperty == null || !Boolean.getBoolean(aboutDisabledProperty)) {
+        if (aboutDisabledProperty == null || !Boolean.parseBoolean(aboutDisabledProperty)) {
             final AboutTab aboutTab = new AboutTab();
             aboutTab.buildLayout(context);
             // FIXME: should be localized

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AbstractDialog.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AbstractDialog.java
@@ -28,7 +28,11 @@ import eu.unifiedviews.helpers.dpu.serialization.xml.SerializationXmlFailure;
 public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<MasterConfigObject>
         implements InitializableConfigDialog {
 
+    private static final long serialVersionUID = 2482689171030846291L;
+
     private static final String ABOUT_DIALOG_PROPERTY = "frontend.dpu.dialog.about.disabled";
+
+    private static final String DPU_CONFIGURATION_TAB_NAME = "dialog.dpu.tab.config";
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDialog.class);
 
@@ -103,7 +107,6 @@ public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<Master
                 LOG.error("Dialog is ignored as it's null: {}", addon.getDialogCaption());
             } else {
                 dialog.buildLayout();
-                // FIXME: should be localized
                 addTab(dialog, addon.getDialogCaption());
                 this.context.addonDialogs.add(dialog);
             }
@@ -113,7 +116,6 @@ public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<Master
         if (aboutDisabledProperty == null || !Boolean.parseBoolean(aboutDisabledProperty)) {
             final AboutTab aboutTab = new AboutTab();
             aboutTab.buildLayout(context);
-            // FIXME: should be localized
             addTab(aboutTab, aboutTab.getCaption());
             // We do not register for this.ctx.addonDialogs.add(dialog); as this is static element.
         }
@@ -129,8 +131,7 @@ public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<Master
             tabSheet.setSelectedTab(0);
             return;
         }
-        // FIXME: should be localized
-        final Tab newTab = tabSheet.addTab(compositionRoot, "DPU configuration");
+        final Tab newTab = tabSheet.addTab(compositionRoot, this.ctx.tr(DPU_CONFIGURATION_TAB_NAME));
         // Remove old one if set, and set new as a master tab (tab with DPU's configuration).
         if (mainTab != null) {
             tabSheet.removeTab(mainTab);
@@ -141,12 +142,13 @@ public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<Master
     }
 
     /**
-     *
-     * @param component Tab to add.
-     * @param caption   Tab name.
+     * @param component
+     *            Tab to add.
+     * @param caption
+     *            Tab name resource for translation
      */
     protected void addTab(Component component, String caption) {
-        final Tab newTab = tabSheet.addTab(component, caption);
+        this.tabSheet.addTab(component, this.ctx.tr(caption));
     }
 
     @Override
@@ -155,7 +157,6 @@ public abstract class AbstractDialog<CONFIG> extends AbstractConfigDialog<Master
     }
 
     /**
-     *
      * @return Dialog originalDialogContext.
      */
     protected ConfigDialogContext getContext() {

--- a/uv-dpu-helpers/src/main/resources/resources_lib.properties
+++ b/uv-dpu-helpers/src/main/resources/resources_lib.properties
@@ -10,3 +10,9 @@ lib.helpers.vaadin.about.git = Git:
 lib.helpers.vaadin.about.git.branch = Branch: 
 lib.helpers.vaadin.about.git.dirty = Dirty: 
 lib.helpers.vaadin.about.git.commit = Commit: 
+
+#DPU dialog
+dialog.dpu.tab.config = DPU configuration
+dialog.dpu.tab.about = About
+dialog.dpu.tab.faulttolerance = Fault tolerance
+dialog.dpu.faulttolerance.enabled = Enable

--- a/uv-dpu-helpers/src/main/resources/resources_lib_sk.properties
+++ b/uv-dpu-helpers/src/main/resources/resources_lib_sk.properties
@@ -5,7 +5,7 @@ lib.boost.execution.cancelled = Vykonávanie zru\u0161ené pou\u017Eívate\u013Eom
 
 # Configuration dialog resources.
 lib.helpers.vaadin.about.buildInfo = Informácie zostavenia
-lib.helpers.vaadin.about.buildTime = \u02C74as zostavenia: 
+lib.helpers.vaadin.about.buildTime = \u010Cas zostavenia: 
 lib.helpers.vaadin.about.git = Git: 
 lib.helpers.vaadin.about.git.branch = Vetva: 
 lib.helpers.vaadin.about.git.dirty = Dirty: 

--- a/uv-dpu-helpers/src/main/resources/resources_lib_sk.properties
+++ b/uv-dpu-helpers/src/main/resources/resources_lib_sk.properties
@@ -1,0 +1,18 @@
+# General resources.
+lib.boost.execution.cancelled = Vykonávanie zru\u0161ené pou\u017Eívate\u013Eom
+
+# Extentsions resources.
+
+# Configuration dialog resources.
+lib.helpers.vaadin.about.buildInfo = Informácie zostavenia
+lib.helpers.vaadin.about.buildTime = \u02C74as zostavenia: 
+lib.helpers.vaadin.about.git = Git: 
+lib.helpers.vaadin.about.git.branch = Vetva: 
+lib.helpers.vaadin.about.git.dirty = Dirty: 
+lib.helpers.vaadin.about.git.commit = Commit:
+
+#DPU dialog
+dialog.dpu.tab.config = Konfigurácia kroku
+dialog.dpu.tab.about = O kroku
+dialog.dpu.tab.faulttolerance = Zotavenie z chýb
+dialog.dpu.faulttolerance.enabled = Povoli\u0165 


### PR DESCRIPTION
As there is no time for eDemo project to translate all about pages to Slovak and it is not desirable to show English texts, there is a need to hide about dialog. This is done via frontend property frontend.dpu.dialog.about.enabled; If it is not present, about dialog is shown;

Another problem with localization are names of tabs (DPU Configuration, About, Fault Tolerance); I haven't been involved in localization but I think there is no support for localization in Plugin-DevEnv. So this would need further investigation