### PR TITLE
SparqlUtils support query with no context

### DIFF
--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/rdf/sparql/SparqlUtils.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/rdf/sparql/SparqlUtils.java
@@ -280,12 +280,12 @@ public class SparqlUtils {
     /**
      *
      * @param query
-     * @param entries
+     * @param entries If empty the SELECT is executed over the whole repository.
      * @return Prepared SPARQL select query object.
      */
     public static SparqlSelectObject createSelect(String query, List<RDFDataUnit.Entry> sources)
             throws SparqlProblemException, DataUnitException {
-        if (!useDataset()) {
+        if (!useDataset() && !sources.isEmpty()) {
             query = query.replaceFirst("(?i)WHERE", prepareClause("FROM", sources) + "WHERE ");
         }
         return new SparqlSelectObject(query, prepareDataset(sources, null));


### PR DESCRIPTION
SparqlUtils now supports select with no context. This is essential for SPARQL endpoint DPUs that query remote repository.

On the other hand it's nothing new as user can query whole repository even now (no new security thread).