### PR TITLE
Pom dependency improvement

### DIFF
--- a/uv-dataunit-files/pom.xml
+++ b/uv-dataunit-files/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom-api/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dataunit-files</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Definition of FilesDataUnit.</description>
 

--- a/uv-dataunit-helpers/pom.xml
+++ b/uv-dataunit-helpers/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-helpers</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom-helpers/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dataunit-helpers</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
 </project>

--- a/uv-dataunit-rdf/pom.xml
+++ b/uv-dataunit-rdf/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom-api/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dataunit-rdf</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Definition of RDFDataUnit.</description>
 

--- a/uv-dataunit-relational/pom.xml
+++ b/uv-dataunit-relational/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom-api/pom.xml</relativePath>
     </parent>
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dataunit-relational</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Definition of RelationalDataUnit.</description>
 

--- a/uv-dpu-api/pom.xml
+++ b/uv-dpu-api/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom-api/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dpu-api</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Contains execution data processing unit APU definitions.</description>
 

--- a/uv-dpu-config-vaadin/pom.xml
+++ b/uv-dpu-config-vaadin/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom-api/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dpu-config-vaadin</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <repositories>

--- a/uv-dpu-helpers/pom.xml
+++ b/uv-dpu-helpers/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-helpers</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom-helpers/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dpu-helpers</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>uv-dpu-helpers</name>
     <description/>

--- a/uv-dpu-helpers/pom.xml
+++ b/uv-dpu-helpers/pom.xml
@@ -15,6 +15,10 @@
     <name>uv-dpu-helpers</name>
     <description/>
 
+    <properties>
+        <unifiedviews.helpers.dataunit.version>2.0.2-SNAPSHOT</unifiedviews.helpers.dataunit.version>
+    </properties>
+
     <developers>
         <developer>
             <name>Petr Škoda</name>
@@ -28,6 +32,7 @@
         <dependency>
             <groupId>eu.unifiedviews</groupId>
             <artifactId>uv-dataunit-helpers</artifactId>
+            <version>${unifiedviews.helpers.dataunit.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Libraries provided by UnifiedViews at runtime. -->

--- a/uv-dpu-template-base/pom.xml
+++ b/uv-dpu-template-base/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-dpu-template-base</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>uv-dpu-template-base</name>
     <description>Template for data processing unit (DPU).</description>

--- a/uv-dpu-template-base/src/main/resources/archetype-resources/pom.xml
+++ b/uv-dpu-template-base/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom-dpu</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>

--- a/uv-pom-api/pom.xml
+++ b/uv-pom-api/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-pom-api</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>uv-pom-api</name>
     <description>Commons base project for API libraries.</description>

--- a/uv-pom-dpu/pom.xml
+++ b/uv-pom-dpu/pom.xml
@@ -4,25 +4,26 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-pom-dpu</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>uv-pom-dpu</name>
     <description>Commons base project for DPU's.</description>
 
     <properties>
+        <unifiedviews.helpers.dataunit.version>2.0.2-SNAPSHOT</unifiedviews.helpers.dataunit.version>
+        <unifiedviews.helpers.dpu.version>2.0.2-SNAPSHOT</unifiedviews.helpers.dpu.version>
 		
         <!-- UV modeules dependecies version for DPUs. -->
         <unifiedviews.module-test.version>2.0.0</unifiedviews.module-test.version>
 
         <!-- versions of 3rd party libraries -->
         <commons.commons-lang3>3.0</commons.commons-lang3>
-
 
         <!-- Must end with comma if not empty. Can be used to influence the OSGI import package list. -->
         <osgi.import.package></osgi.import.package>
@@ -43,6 +44,17 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>eu.unifiedviews</groupId>
+                <artifactId>uv-dataunit-helpers</artifactId>
+                <version>${unifiedviews.helpers.dataunit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>eu.unifiedviews</groupId>
+                <artifactId>uv-dpu-helpers</artifactId>
+                <version>${unifiedviews.helpers.dpu.version}</version>
+            </dependency>
+
+			<dependency>
                 <groupId>eu.unifiedviews</groupId>
                 <artifactId>module-test</artifactId>
                 <version>${unifiedviews.module-test.version}</version>

--- a/uv-pom-helpers/pom.xml
+++ b/uv-pom-helpers/pom.xml
@@ -16,27 +16,9 @@
     <description>Base project for libraries.</description>
 
     <properties>
-        <unifiedviews.helpers.dataunit.version>2.0.2-SNAPSHOT</unifiedviews.helpers.dataunit.version>
-        <unifiedviews.helpers.dpu.version>2.0.2-SNAPSHOT</unifiedviews.helpers.dpu.version>
-
-		<!-- Must end with comma if not empty. -->
+        <!-- Must end with comma if not empty. -->
         <osgi.import.package></osgi.import.package>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>eu.unifiedviews</groupId>
-                <artifactId>uv-dataunit-helpers</artifactId>
-                <version>${unifiedviews.helpers.dataunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>eu.unifiedviews</groupId>
-                <artifactId>uv-dpu-helpers</artifactId>
-                <version>${unifiedviews.helpers.dpu.version}</version>
-            </dependency>
-		</dependencies>
-	</dependencyManagement>
 
     <dependencies>
         <!-- Unifiedviews API. -->

--- a/uv-pom-helpers/pom.xml
+++ b/uv-pom-helpers/pom.xml
@@ -4,21 +4,39 @@
     <parent>
         <groupId>eu.unifiedviews</groupId>
         <artifactId>uv-pom</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../uv-pom/pom.xml</relativePath>
     </parent>
 
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-pom-helpers</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>uv-pom-helpers</name>
     <description>Base project for libraries.</description>
 
     <properties>
-        <!-- Must end with comma if not empty. -->
+        <unifiedviews.helpers.dataunit.version>2.0.2-SNAPSHOT</unifiedviews.helpers.dataunit.version>
+        <unifiedviews.helpers.dpu.version>2.0.2-SNAPSHOT</unifiedviews.helpers.dpu.version>
+
+		<!-- Must end with comma if not empty. -->
         <osgi.import.package></osgi.import.package>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>eu.unifiedviews</groupId>
+                <artifactId>uv-dataunit-helpers</artifactId>
+                <version>${unifiedviews.helpers.dataunit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>eu.unifiedviews</groupId>
+                <artifactId>uv-dpu-helpers</artifactId>
+                <version>${unifiedviews.helpers.dpu.version}</version>
+            </dependency>
+		</dependencies>
+	</dependencyManagement>
 
     <dependencies>
         <!-- Unifiedviews API. -->

--- a/uv-pom/pom.xml
+++ b/uv-pom/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.unifiedviews</groupId>
     <artifactId>uv-pom</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>uv-pom</name>
 
@@ -17,9 +17,7 @@
 
     <properties>
         <!-- UV version for dependencies. -->
-        <unifiedviews.api.version>2.0.1</unifiedviews.api.version>
-        <unifiedviews.helpers.dataunit.version>2.0.1</unifiedviews.helpers.dataunit.version>
-        <unifiedviews.helpers.dpu.version>2.0.1</unifiedviews.helpers.dpu.version>
+        <unifiedviews.api.version>2.0.2-SNAPSHOT</unifiedviews.api.version>
 
         <!-- Used bundle plugin version. -->
         <bundle.plugin.version>2.3.7</bundle.plugin.version>
@@ -75,16 +73,6 @@
                 <groupId>eu.unifiedviews</groupId>
                 <artifactId>uv-dataunit-relational</artifactId>
                 <version>${unifiedviews.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>eu.unifiedviews</groupId>
-                <artifactId>uv-dataunit-helpers</artifactId>
-                <version>${unifiedviews.helpers.dataunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>eu.unifiedviews</groupId>
-                <artifactId>uv-dpu-helpers</artifactId>
-                <version>${unifiedviews.helpers.dpu.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Motivation:
to be able to increase version of helpers without change of API version.

Version 2.0.1 behaviour:
Dependency management in uv-pom/pom.xml and this pom is also parent pom for other, So change in version of helpers in this file push changes in versions of all pom files. 

Changes done:
- Dependency management moved to uv-pom-dpu, so DPU reuse baseline as is defined in it's parent pom (uv-pom-dpu).
- version of API is defined in uv-pom, so change in API version triggers changes in helpers versions and also in DPUs versions (if DPU requires newer API).
- version of dataunit helpers is defined in dpu-helpers and uv-pom-dpu
- version of dpu-helpers is defined in uv-pom-dpu and depends directly on version of dataunit-helpers.

