### PR TITLE
DPU dialog context extended, changes in DPU execution context

### DIFF
--- a/uv-dpu-api/src/main/java/eu/unifiedviews/dpu/DPUContext.java
+++ b/uv-dpu-api/src/main/java/eu/unifiedviews/dpu/DPUContext.java
@@ -114,21 +114,21 @@ public interface DPUContext {
      * 
      * @return Pipeline execution owner name
      */
-    String getPipelineExecutorUserName();
+    String getPipelineExecutionOwner();
 
     /**
      * Return the external Id of user who started or scheduled the pipeline execution
      * 
      * @return Pipeline execution owner external Id
      */
-    String getPipelineExecutorUserExternalId();
+    String getPipelineExecutionOwnerExternalId();
 
     /**
      * If pipeline executing user has meta data (actor), returns actor external Id
      * 
      * @return actor id if present, null otherwise
      */
-    String getPipelineExecutorActorExternalId();
+    String getPipelineExecutionActorExternalId();
 
     /**
      * @deprecated Organization concept has been removed from UV and was replaced by actor concept; To provide

--- a/uv-dpu-api/src/main/java/eu/unifiedviews/dpu/DPUContext.java
+++ b/uv-dpu-api/src/main/java/eu/unifiedviews/dpu/DPUContext.java
@@ -94,9 +94,18 @@ public interface DPUContext {
     boolean isDebugging();
 
     /**
-     * Return the pipeline owner user id
+     * Return the user name of user who started or scheduled the pipeline execution
+     * 
+     * @return Pipeline execution owner name
      */
-    String getPipelineOwner();
+    String getPipelineExecutorUserName();
+
+    /**
+     * Return the external Id of user who started or scheduled the pipeline execution
+     * 
+     * @return Pipeline execution owner external Id
+     */
+    String getPipelineExecutorUserExternalId();
 
     /**
      * Return the pipeline owner organization

--- a/uv-dpu-api/src/main/java/eu/unifiedviews/dpu/DPUContext.java
+++ b/uv-dpu-api/src/main/java/eu/unifiedviews/dpu/DPUContext.java
@@ -103,6 +103,13 @@ public interface DPUContext {
     boolean isDebugging();
 
     /**
+     * Return pipeline owner user name
+     * 
+     * @return Pipeline owner user name
+     */
+    String getPipelineOwner();
+
+    /**
      * Return the user name of user who started or scheduled the pipeline execution
      * 
      * @return Pipeline execution owner name

--- a/uv-dpu-config-vaadin/src/main/java/eu/unifiedviews/dpu/config/vaadin/ConfigDialogContext.java
+++ b/uv-dpu-config-vaadin/src/main/java/eu/unifiedviews/dpu/config/vaadin/ConfigDialogContext.java
@@ -22,7 +22,22 @@ public interface ConfigDialogContext {
 
     /**
      * Return the execution environment variables
+     * 
      * @return
      */
     Map<String, String> getEnvironment();
+
+    /**
+     * Returns logged user external Id
+     * 
+     * @return Users' external Id
+     */
+    String getUserExternalId();
+
+    /**
+     * Returns logged user Id
+     * 
+     * @return Users' Id
+     */
+    Long getUserId();
 }


### PR DESCRIPTION
New methods added to DPU dialog context to provide information about logged user. This information is needed in design time of pipeline for some new DPUs retrieving data from CKAN catalog.
Method in DPU execution context interface renamed as actual name does not correspond to what the method really returns;