### PR TITLE
Global disable of DPU optional tabs

### DIFF
--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/extension/faulttolerance/FaultTolerance.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/extension/faulttolerance/FaultTolerance.java
@@ -2,6 +2,7 @@ package eu.unifiedviews.helpers.dpu.extension.faulttolerance;
 
 import java.util.LinkedList;
 import java.util.List;
+
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
 import org.slf4j.Logger;
@@ -87,7 +88,7 @@ public class FaultTolerance implements Extension, Configurable<FaultTolerance.Co
         /**
          * If false no fault tolerance is provided by this add-on.
          */
-        private boolean enabled = true;
+        private boolean enabled = false;
 
         /**
          * Store names of exceptions that should be catch.


### PR DESCRIPTION
Implemented generic disabling of DPU optional features (tabs); This is solution of issue #32 

Tabs can be disabled in frontend configuration using properties frontend.dpu.tab.disabled.{Tab class name / Configurable class name}

By default (when no property is given), feature (tab) is displayed; 
Also, fault tolerance is now by default off (tab is by default still displayed) - user must explicitly enable this for each DPU

Examples for existing tabs / configurables
- frontend.dpu.tab.disabled.AboutTab = true
- frontend.dpu.tab.disabled.FaultTolerance = true 
- frontend.dpu.tab.disabled.ConfigCopyPasteTab = true