### PR TITLE
Generation of About<_lang>.html from About<_lang>.md

### DIFF
--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -107,15 +107,26 @@ public class AboutTab extends CustomComponent {
         final Locale locale = context.getDialogContext().getLocale();
         // TODO Petr: This is probably not a good idea how to do this.
         // Try file based on curent localzation.
-        String fileName = "About_" + locale.toLanguageTag() + ".html";
-        final String result = loadStringFromResource(classLoader, fileName);
-        if (result != null) {
-            return result;
-        } else {
-            // Use fallback.
-            fileName = "About.html";
-            return loadStringFromResource(classLoader, fileName);
+        
+        String fileNames [] = { "About", "about"};
+        for( String filenamePrefix : fileNames) {
+            String fileName = filenamePrefix + locale.toLanguageTag() + ".html";
+            final String result = loadStringFromResource(classLoader, fileName);
+            if (result != null) {
+                return result;
+            }
         }
+        // Check (fallback) default nonlocalized About files
+        for( String filenamePrefix : fileNames) {
+            String fileName = filenamePrefix + ".html";
+            final String result = loadStringFromResource(classLoader, fileName);
+            if (result != null) {
+                return result;
+            }
+        }
+        // no About found
+        return null;
+  
     }
 
     protected String loadStringFromResource(ClassLoader classLoader, String resourceName) {

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -84,9 +84,10 @@ public class AboutTab extends CustomComponent {
             mainLayout.addComponent(new Label(userDescription, ContentMode.HTML));
         }
 
-        final StringBuilder aboutHtml = new StringBuilder("<hr/>");
+        final StringBuilder aboutHtml = new StringBuilder("<hr/><p style='align:right'>");
         aboutHtml.append(ctx.tr("lib.helpers.vaadin.about.buildTime"));
         aboutHtml.append(buildInfo.getString("build.timestamp"));
+        aboutHtml.append("</p>");
 
         final String gitInfo = buildGitInfo(buildInfo, ctx);
         if (gitInfo != null) {

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -107,13 +107,13 @@ public class AboutTab extends CustomComponent {
         final Locale locale = context.getDialogContext().getLocale();
         // TODO Petr: This is probably not a good idea how to do this.
         // Try file based on curent localzation.
-        String fileName = "about_" + locale.toLanguageTag() + ".html";
+        String fileName = "About_" + locale.toLanguageTag() + ".html";
         final String result = loadStringFromResource(classLoader, fileName);
         if (result != null) {
             return result;
         } else {
             // Use fallback.
-            fileName = "about.html";
+            fileName = "About.html";
             return loadStringFromResource(classLoader, fileName);
         }
     }

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -84,7 +84,7 @@ public class AboutTab extends CustomComponent {
             mainLayout.addComponent(new Label(userDescription, ContentMode.HTML));
         }
 
-        final StringBuilder aboutHtml = new StringBuilder();
+        final StringBuilder aboutHtml = new StringBuilder("<hr/>");
         aboutHtml.append(ctx.tr("lib.helpers.vaadin.about.buildTime"));
         aboutHtml.append(buildInfo.getString("build.timestamp"));
 

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -53,8 +53,6 @@ public class AboutTab extends CustomComponent {
 
     private final String BUNDLE_NAME = "build-info";
 
-    private final String HTML_FOOTER = "<br/><hr/>"
-            + "Powered by <a href=\"https://github.com/mff-uk\">CUNI helpers</a>.";
 
     public AboutTab() {
         // No-op here.
@@ -78,31 +76,7 @@ public class AboutTab extends CustomComponent {
         // Just as a shortcut for translation.
         final UserContext ctx = context.asUserContext();
 
-        final StringBuilder aboutHtml = new StringBuilder();
-        aboutHtml.append("<b>");
-        aboutHtml.append(ctx.tr("lib.helpers.vaadin.about.buildInfo"));
-        aboutHtml.append("</b></br>");
-        aboutHtml.append("<ul>");
-
-        aboutHtml.append("<li>");
-        aboutHtml.append(ctx.tr("lib.helpers.vaadin.about.buildTime"));
-        aboutHtml.append(buildInfo.getString("build.timestamp"));
-        aboutHtml.append("</li>");
-
-        final String gitInfo = buildGitInfo(buildInfo, ctx);
-        if (gitInfo != null) {
-            aboutHtml.append("<li>");
-            aboutHtml.append(gitInfo);
-            aboutHtml.append("</li>");
-        }
-
-        aboutHtml.append("</ul>");
-        aboutHtml.append("<hr/>");
-
         // Load optional properties.
-
-        // Add generated text into a dilaog.
-        mainLayout.addComponent(new Label(aboutHtml.toString(), ContentMode.HTML));
 
         // Add user provided description if available.
         final String userDescription = loadUserAboutText(context);
@@ -110,8 +84,17 @@ public class AboutTab extends CustomComponent {
             mainLayout.addComponent(new Label(userDescription, ContentMode.HTML));
         }
 
-        // Logo at the verz end.
-        mainLayout.addComponent(new Label(HTML_FOOTER, ContentMode.HTML));
+        final StringBuilder aboutHtml = new StringBuilder();
+        aboutHtml.append(ctx.tr("lib.helpers.vaadin.about.buildTime"));
+        aboutHtml.append(buildInfo.getString("build.timestamp"));
+
+        final String gitInfo = buildGitInfo(buildInfo, ctx);
+        if (gitInfo != null) {
+            aboutHtml.append(gitInfo);
+        }
+
+        // Add generated text into a dilaog.
+        mainLayout.addComponent(new Label(aboutHtml.toString(), ContentMode.HTML));
 
         // Wrap all into a panel.
         final Panel panel = new Panel();

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -84,7 +84,7 @@ public class AboutTab extends CustomComponent {
             mainLayout.addComponent(new Label(userDescription, ContentMode.HTML));
         }
 
-        final StringBuilder aboutHtml = new StringBuilder("<hr/><p align=\"right\">");
+        final StringBuilder aboutHtml = new StringBuilder("<hr/><p style=\"text-align:right\">");
         aboutHtml.append(ctx.tr("lib.helpers.vaadin.about.buildTime"));
         aboutHtml.append(buildInfo.getString("build.timestamp"));
         aboutHtml.append("</p>");

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -102,22 +104,42 @@ public class AboutTab extends CustomComponent {
         setCompositionRoot(panel);
     }
 
+    protected List<String> calculateFilenamesForLocale(String basename, Locale locale) {
+        List<String> result = new ArrayList<String>(3);
+        String language = locale.getLanguage();
+        String country = locale.getCountry();
+        String variant = locale.getVariant();
+        StringBuilder temp = new StringBuilder(basename);
+
+        temp.append('_');
+        if (language.length() > 0) {
+            temp.append(language);
+            result.add(0, temp.toString());
+        }
+
+        temp.append('_');
+        if (country.length() > 0) {
+            temp.append(country);
+            result.add(0, temp.toString());
+        }
+
+        if (variant.length() > 0 && (language.length() > 0 || country.length() > 0)) {
+            temp.append('_').append(variant);
+            result.add(0, temp.toString());
+        }
+
+        return result;
+    }
+
     protected String loadUserAboutText(DialogContext context) {
         final ClassLoader classLoader = context.getDpuClass().getClassLoader();
         final Locale locale = context.getDialogContext().getLocale();
-        // TODO Petr: This is probably not a good idea how to do this.
-        // Try file based on curent localzation.
-        
-        String fileNames [] = { "About", "about"};
-        for( String filenamePrefix : fileNames) {
-            String fileName = filenamePrefix + locale.toLanguageTag() + ".html";
-            final String result = loadStringFromResource(classLoader, fileName);
-            if (result != null) {
-                return result;
-            }
-        }
-        // Check (fallback) default nonlocalized About files
-        for( String filenamePrefix : fileNames) {
+
+        List<String> fileNames = calculateFilenamesForLocale("About", locale);
+        fileNames.addAll(calculateFilenamesForLocale("about", locale));
+        fileNames.add("About");
+        fileNames.add("about");
+        for (String filenamePrefix : fileNames) {
             String fileName = filenamePrefix + ".html";
             final String result = loadStringFromResource(classLoader, fileName);
             if (result != null) {
@@ -126,7 +148,7 @@ public class AboutTab extends CustomComponent {
         }
         // no About found
         return null;
-  
+
     }
 
     protected String loadStringFromResource(ClassLoader classLoader, String resourceName) {
@@ -149,7 +171,6 @@ public class AboutTab extends CustomComponent {
     }
 
     /**
-     *
      * @param buildInfo
      * @param ctx
      * @return Null if no GIT related info is available.

--- a/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
+++ b/uv-dpu-helpers/src/main/java/eu/unifiedviews/helpers/dpu/vaadin/dialog/AboutTab.java
@@ -84,7 +84,7 @@ public class AboutTab extends CustomComponent {
             mainLayout.addComponent(new Label(userDescription, ContentMode.HTML));
         }
 
-        final StringBuilder aboutHtml = new StringBuilder("<hr/><p style='align:right'>");
+        final StringBuilder aboutHtml = new StringBuilder("<hr/><p align=\"right\">");
         aboutHtml.append(ctx.tr("lib.helpers.vaadin.about.buildTime"));
         aboutHtml.append(buildInfo.getString("build.timestamp"));
         aboutHtml.append("</p>");

--- a/uv-dpu-helpers/src/main/resources/resources_lib.properties
+++ b/uv-dpu-helpers/src/main/resources/resources_lib.properties
@@ -20,7 +20,6 @@ lib.boost.execution.cancelled = Execution cancelled by user.
 # Extentsions resources.
 
 # Configuration dialog resources.
-lib.helpers.vaadin.about.buildInfo = Build info
 lib.helpers.vaadin.about.buildTime = Build time: 
 lib.helpers.vaadin.about.git = Git: 
 lib.helpers.vaadin.about.git.branch = Branch: 

--- a/uv-dpu-helpers/src/main/resources/resources_lib_sk.properties
+++ b/uv-dpu-helpers/src/main/resources/resources_lib_sk.properties
@@ -20,7 +20,6 @@ lib.boost.execution.cancelled = Vykonávanie zru\u0161ené pou\u017Eívate\u013Eom
 # Extentsions resources.
 
 # Configuration dialog resources.
-lib.helpers.vaadin.about.buildInfo = Informácie zostavenia
 lib.helpers.vaadin.about.buildTime = \u010Cas zostavenia: 
 lib.helpers.vaadin.about.git = Git: 
 lib.helpers.vaadin.about.git.branch = Vetva: 

--- a/uv-pom-dpu/pom.xml
+++ b/uv-pom-dpu/pom.xml
@@ -123,12 +123,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Build plugins dependencies -->
-        <dependency>
-            <groupId>com.ruleoftech</groupId>
-            <artifactId>markdown-page-generator-plugin</artifactId>
-            <version>0.4</version>
-        </dependency>
 
     </dependencies>
 

--- a/uv-pom-dpu/pom.xml
+++ b/uv-pom-dpu/pom.xml
@@ -117,11 +117,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>eu.unifiedviews</groupId>
+            <artifactId>module-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Build plugins dependencies -->
         <dependency>

--- a/uv-pom-dpu/pom.xml
+++ b/uv-pom-dpu/pom.xml
@@ -200,7 +200,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputDirectory>${basedir}/src/main/resources</inputDirectory>
+                            <inputDirectory>${basedir}/doc</inputDirectory>
                             <outputDirectory>${basedir}/target/html</outputDirectory>
                             <inputEncoding>UTF-8</inputEncoding>
                             <outputEncoding>UTF-8</outputEncoding>

--- a/uv-pom-dpu/pom.xml
+++ b/uv-pom-dpu/pom.xml
@@ -116,6 +116,14 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Build plugins dependencies -->
+        <dependency>
+            <groupId>com.ruleoftech</groupId>
+            <artifactId>markdown-page-generator-plugin</artifactId>
+            <version>0.4</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>
@@ -166,8 +174,34 @@
                     <exclude>build-info.properties</exclude>
                 </excludes>
             </resource>
+            <resource>
+                <directory>${basedir}/target/html</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>About*.html</include>
+                </includes>
+            </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>com.ruleoftech</groupId>
+                <artifactId>markdown-page-generator-plugin</artifactId>
+                <version>0.7</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputDirectory>${basedir}/src/main/resources</inputDirectory>
+                            <outputDirectory>${basedir}/target/html</outputDirectory>
+                            <inputEncoding>UTF-8</inputEncoding>
+                            <outputEncoding>UTF-8</outputEncoding>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin> <!-- Main build plugin. -->
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
Support to generate About.html using convertor from markdown to html (https://github.com/walokra/markdown-page-generator-plugin)

Connected to #41 
Resolves #30 
