### PR TITLE
ModuleTest dependency pre-defined in uv-pom-dpu

### DIFF
--- a/uv-pom-dpu/pom.xml
+++ b/uv-pom-dpu/pom.xml
@@ -55,14 +55,15 @@
             </dependency>
 
             <dependency>
-                <groupId>eu.unifiedviews</groupId>
-                <artifactId>module-test</artifactId>
-                <version>${unifiedviews.module-test.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons.commons-lang3}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>eu.unifiedviews</groupId>
+                <artifactId>module-test</artifactId>
+                <version>${unifiedviews.module-test.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -116,6 +117,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>eu.unifiedviews</groupId>
+			<artifactId>module-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Module test dependency defined in uv-pom-dpu. DPUs reuse it with version in scope test.