### PR TITLE
Helper methods for files/RDF data units unified, comments adjusted

### DIFF
--- a/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/files/FilesDataUnitUtils.java
+++ b/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/files/FilesDataUnitUtils.java
@@ -25,7 +25,8 @@ import eu.unifiedviews.dataunit.files.WritableFilesDataUnit;
 import eu.unifiedviews.helpers.dataunit.virtualpath.VirtualPathHelper;
 
 /**
- * Utils for working with file data units.
+ * Utils for working with {@link eu.unifiedviews.dataunit.files.FilesDataUnit}. DPU developer should NOT use this class directly - he should use
+ * {@link FilesHelper}.
  * 
  * @author Škoda Petr
  */

--- a/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/files/FilesHelper.java
+++ b/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/files/FilesHelper.java
@@ -23,18 +23,28 @@ import java.util.Set;
 
 import eu.unifiedviews.dataunit.DataUnitException;
 import eu.unifiedviews.dataunit.files.FilesDataUnit;
+import eu.unifiedviews.dataunit.files.WritableFilesDataUnit;
+import eu.unifiedviews.dpu.DPUException;
+import java.io.File;
 
 /**
- * Helper to make various tasks with {@link FilesDataUnit} friendly.
+ * Helper to simplify fetching files entries from input {@link eu.unifiedviews.dataunit.files.FilesDataUnit},
+ * operating with file entries, and writing file entries to output {@link eu.unifiedviews.dataunit.files.FilesDataUnit}.
+ * This class should be used as the main class by DPU developers who needs helpers to operate with {@link eu.unifiedviews.dataunit.files.FilesDataUnit}.
  */
 public class FilesHelper {
+
     /**
-     * Exhaust {@link eu.unifiedviews.dataunit.files.FilesDataUnit.Iteration} (obtained using {@link eu.unifiedviews.dataunit.files.FilesDataUnit#getIteration()}) into one {@link Map} of entries.
-     * Beware - if the {@link eu.unifiedviews.dataunit.files.FilesDataUnit} contains milions or more entries, storing all of this in single {@link Map} is not a good idea.
-     * Only suitable for work with ~100000 of entries (files)
-     *
-     * @param filesDataUnit data unit from which the iteration will be obtained and exhausted
-     * @return {@link Map} containing all entries, keys are symbolic names
+     * Gets file entries from the given {@link eu.unifiedviews.dataunit.files.FilesDataUnit}.
+     * This method internally iterates over entries in the {@link eu.unifiedviews.dataunit.files.FilesDataUnit} and stores the entries into one {@link Map} of
+     * entries.
+     * Only suitable for ~10000 of entries (files) in the given {@link eu.unifiedviews.dataunit.files.FilesDataUnit}, because all entries are stored into a
+     * {@link Set}. For bigger amounts of files, it is better to directly use {@link eu.unifiedviews.dataunit.files.FilesDataUnit.Iteration} to iterate over the
+     * files and directly process them.
+     * 
+     * @param filesDataUnit
+     *            data unit from which the entries are fetched
+     * @return {@link Map} containing all entries in the given data unit, keys are symbolic names
      * @throws DataUnitException
      */
     public static Map<String, FilesDataUnit.Entry> getFilesMap(FilesDataUnit filesDataUnit) throws DataUnitException {
@@ -55,12 +65,16 @@ public class FilesHelper {
     }
 
     /**
-     * Exhaust {@link eu.unifiedviews.dataunit.files.FilesDataUnit.Iteration} (obtained using {@link eu.unifiedviews.dataunit.files.FilesDataUnit#getIteration()}) into one {@link Set} of entries.
-     * Beware - if the {@link eu.unifiedviews.dataunit.files.FilesDataUnit} contains milions or more entries, storing all of this in single {@link Set} is not a good idea.
-     * Only suitable for work with ~100000 of entries (files)
-     *
-     * @param filesDataUnit data unit from which the iteration will be obtained and exhausted
-     * @return {@link Set} containing all entries
+     * Gets file entries from the given {@link eu.unifiedviews.dataunit.files.FilesDataUnit}.
+     * This method internally iterates over entries in the {@link eu.unifiedviews.dataunit.files.FilesDataUnit} and stores the entries into one {@link Set} of
+     * entries.
+     * Only suitable for ~10000 of entries (files) in the given {@link eu.unifiedviews.dataunit.files.FilesDataUnit}, because all entries are stored into a
+     * {@link Set}. For bigger amounts of files, it is better to directly use {@link eu.unifiedviews.dataunit.files.FilesDataUnit.Iteration} to iterate over the
+     * files and directly process them.
+     * 
+     * @param filesDataUnit
+     *            data unit from which the entries are fetched
+     * @return {@link Set} containing all entries in the given data unit
      * @throws DataUnitException
      */
     public static Set<FilesDataUnit.Entry> getFiles(FilesDataUnit filesDataUnit) throws DataUnitException {
@@ -79,4 +93,79 @@ public class FilesHelper {
         }
         return resultSet;
     }
+
+    /**
+     * Creates new empty file in the {@link eu.unifiedviews.dataunit.files.WritableFilesDataUnit} with the symbolicName metadata equal to
+     * filename.
+     * The physical name of the created file is generated and the file is physically stored in the working directory of the given pipeline execution.
+     * It also automatically adds {@link VirtualPathHelper#PREDICATE_VIRTUAL_PATH} metadata to
+     * the new file, which is equal to filename.
+     * Note: This function creates new connection to the RDF working store (where metadata of entries are held) anytime it is called
+     * 
+     * @param filesDataUnit
+     *            data unit in which the file should be created
+     * @param filename
+     * @return Files entry pointing to the create file.
+     * @throws DataUnitException
+     */
+    public static FilesDataUnit.Entry createFile(WritableFilesDataUnit filesDataUnit, final String filename) throws DataUnitException {
+        return FilesDataUnitUtils.createFile(filesDataUnit, filename);
+    }
+
+    /**
+     * Adds existing file to the {@link eu.unifiedviews.dataunit.files.WritableFilesDataUnit}.
+     * It automatically creates new entry in the output data unit with the symbolicName and virtualPath metadata equal to filename.
+     * The real location and the physical name of the file is as it was when it was created before calling this method. Be careful that the file
+     * is not created in the working space of the given pipeline execution.
+     * It also automatically adds {@link VirtualPathHelper#PREDICATE_VIRTUAL_PATH} metadata to
+     * the new file, which is equal to filename.
+     * Note: This function creates new connection to the RDF working store (where metadata of entries are held) anytime it is called
+     * 
+     * @param filesDataUnit
+     *            data unit to which the file should be added
+     * @param file
+     *            File to be added
+     * @param fileName
+     *            The name under which the file should be added
+     * @throws DPUException
+     */
+    public static FilesDataUnit.Entry addFile(WritableFilesDataUnit filesDataUnit, final File file, final String filename) throws DataUnitException {
+        return FilesDataUnitUtils.addFile(filesDataUnit, file, filename);
+    }
+
+    /**
+     * Adds existing file to the {@link eu.unifiedviews.dataunit.files.WritableFilesDataUnit}.
+     * It automatically creates new entry in the output data unit with the symbolicName and virtualPath metadata equal to filename, which is automatically
+     * computed as file.getName().
+     * The real location and the physical name of the file is as it was when it was created before calling this method. Be careful that the file
+     * is not created in the working space of the given pipeline execution.
+     * It also automatically adds {@link VirtualPathHelper#PREDICATE_VIRTUAL_PATH} metadata to
+     * the new file, which is equal to filename.
+     * Note: This function creates new connection to the RDF working store (where metadata of entries are held) anytime it is called
+     * 
+     * @param filesDataUnit
+     *            data unit to which the file should be added
+     * @param file
+     *            File to be added
+     * @param fileName
+     *            The name under which the file should be added
+     * @throws DPUException
+     */
+    public static FilesDataUnit.Entry addFile(WritableFilesDataUnit filesDataUnit, final File file) throws DataUnitException {
+        return FilesDataUnitUtils.addFile(filesDataUnit, file);
+
+    }
+
+    /**
+     * Converts files entry to standard Java File object.
+     * 
+     * @param entry
+     *            File entry to be converted
+     * @return File representation of the given entry.
+     * @throws DataUnitException
+     */
+    public static File asFile(FilesDataUnit.Entry entry) throws DataUnitException {
+        return FilesDataUnitUtils.asFile(entry);
+    }
+
 }

--- a/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/rdf/RDFHelper.java
+++ b/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/rdf/RDFHelper.java
@@ -27,18 +27,26 @@ import org.openrdf.repository.RepositoryConnection;
 
 import eu.unifiedviews.dataunit.DataUnitException;
 import eu.unifiedviews.dataunit.rdf.RDFDataUnit;
+import eu.unifiedviews.dataunit.rdf.WritableRDFDataUnit;
 import eu.unifiedviews.helpers.dataunit.dataset.DatasetBuilder;
+import java.util.List;
 
 /**
- * Helper to make various tasks with {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} friendly.
+ * Helper to simplify fetching RDF graphs entries from input {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit},
+ * operating with RDF graphs, and writing RDF graphs to output {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}.
+ * This class should be used as the main class by DPU developers who needs helpers to operate with {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}.
  */
 public class RDFHelper {
     /**
-     * Exhaust {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} (obtained using {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit#getIteration()}) into one {@link Map} of entries.
-     * Beware - if the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} contains milions or more entries, storing all of this in single {@link Map} is not a good idea.
-     * Only suitable for work with ~100000 of entries (graphs)
-     *
-     * @param rdfDataUnit data unit from which the iteration will be obtained and exhausted
+     * Gets entries from the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}.
+     * This method internally iterates over entries in the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} and stores the entries into one {@link Map} of
+     * entries.
+     * Only suitable for ~10000 of entries in the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}, because all entries are stored into a {@link Map}. For
+     * bigger amounts of entries, it is better to directly use {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} to iterate over the
+     * entries and directly process them.
+     * 
+     * @param rdfDataUnit
+     *            data unit from which the entries are fetched
      * @return {@link Map} containing all entries, symbolic names are used as keys
      * @throws DataUnitException
      */
@@ -60,11 +68,15 @@ public class RDFHelper {
     }
 
     /**
-     * Exhaust {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} (obtained using {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit#getIteration()}) into one {@link Set} of entries.
-     * Beware - if the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} contains milions or more entries, storing all of this in single {@link Set} is not a good idea.
-     * Only suitable for work with ~100000 of entries (graphs)
-     *
-     * @param rdfDataUnit data unit from which the iteration will be obtained and exhausted
+     * Gets entries from the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}.
+     * This method internally iterates over entries in the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} and stores the entries into one {@link Set} of
+     * entries.
+     * Only suitable for ~10000 of entries in the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}, because all entries are stored into a {@link Set}. For
+     * bigger amounts of entries, it is better to directly use {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} to iterate over the
+     * entries and directly process them.
+     * 
+     * @param rdfDataUnit
+     *            data unit from which the entries are fetched
      * @return {@link Set} containing all entries
      * @throws DataUnitException
      */
@@ -86,15 +98,26 @@ public class RDFHelper {
     }
 
     /**
-     * Exhaust {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} (obtained using {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit#getIteration()}) into one {@link Set} of graph URIs (throw away symbolic names).
-     * Beware - if the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} contains milions or more entries, storing all of this in single {@link Set} is not a good idea.
-     * Only suitable for work with ~100000 of entries (graphs)
+     * Gets entries from the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}.
+     * This method internally iterates over entries in the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} and stores the entries into one {@link Set} of
+     * of data graph URIs.
+     * Only suitable for ~10000 of entries in the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}, because all entries are stored into a {@link Set}. For
+     * bigger amounts of entries, it is better to directly use {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} to iterate over the
+     * entries and directly process them.
      * <p>
      * Useful for feeding {@link Dataset} class (together with {@link DatasetBuilder}):
-     * <p><blockquote><pre>
+     * <p>
+     * <blockquote>
+     * 
+     * <pre>
      * query.setDataset(new DatasetBuilder().withNamedGraphs(RDFHelper.getGraphsURISet(inputDataUnit)).build())
-     * </pre></blockquote></p>
-     * @param rdfDataUnit data unit from which the iteration will be obtained and exhausted
+     * </pre>
+     * 
+     * </blockquote>
+     * </p>
+     * 
+     * @param rdfDataUnit
+     *            data unit from which the entries are fetched
      * @return {@link Set} containing all graphs from the rdfDataUnit
      * @throws DataUnitException
      */
@@ -116,15 +139,26 @@ public class RDFHelper {
     }
 
     /**
-     * Exhaust {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} (obtained using {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit#getIteration()}) into one array of graph URIs (throw away symbolic names).
-     * Beware - if the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} contains milions or more entries, storing all of this in single array is not a good idea.
-     * Only suitable for work with ~100000 of entries (graphs)
+     * Gets entries from the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}.
+     * This method internally iterates over entries in the {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} and stores the entries into one array of
+     * of data graph URIs.
+     * Only suitable for ~10000 of entries in the given {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit}, because all entries are stored into an array. For
+     * bigger amounts of entries, it is better to directly use {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit.Iteration} to iterate over the
+     * entries and directly process them.
      * <p>
      * Useful for methods from {@link RepositoryConnection} which are varargs. Such as
-     * <p><blockquote><pre>
+     * <p>
+     * <blockquote>
+     * 
+     * <pre>
      * connection.add(statement, RDFHelper.getGraphsURIArray(outputDataUnit));
-     * </pre></blockquote></p>
-     * @param rdfDataUnit data unit from which the iteration will be obtained and exhausted
+     * </pre>
+     * 
+     * </blockquote>
+     * </p>
+     * 
+     * @param rdfDataUnit
+     *            data unit from which the entries are fetched
      * @return array of URIs containing all graphs from the rdfDataUnit
      * @throws DataUnitException
      */
@@ -133,22 +167,38 @@ public class RDFHelper {
     }
 
     /**
-     * Most simple way to obtain dataset where all graphs stored in {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} are set as default graphs.
+     * To create instance of Dataset class (from OpenRDF API) for which all RDF data graphs from {@link eu.unifiedviews.dataunit.rdf.RDFDataUnit} are set as
+     * default graphs.
+     * Suitable for further querying.
      * <p>
      * Used to shorten this (more verbose) way of creating equivalent dataset:
-     * <p><blockquote><pre>
+     * <p>
+     * <blockquote>
+     * 
+     * <pre>
      * query.setDataset(new DatasetBuilder().withDefaultGraphs(RDFHelper.getGraphsURISet(inputDataUnit)).build())
-     * </pre></blockquote></p>
+     * </pre>
+     * 
+     * </blockquote>
+     * </p>
      * into shortened form using this method:
-     * <p><blockquote><pre>
+     * <p>
+     * <blockquote>
+     * 
+     * <pre>
      * query.setDataset(RDFHelper.getDatasetWithDefaultGraphs(inputDataUnit)))
-     * </pre></blockquote></p>
+     * </pre>
+     * 
+     * </blockquote>
+     * </p>
      * Beware that this method refuses to create dataset with empty defaultGraphs parameter. This is to prevent
      * bugs and errors, as with different storages the empty defaultGraphs may be interpreted in different ways.
-     *
-     * @param rdfDataUnit data unit from which to obtain all graphs
-     * @return {@link Dataset} with defaultGraphs set to all graphs from data unit
-     * @throws DataUnitException when rdfDataUnit does contain no graphs or connection errors.
+     * 
+     * @param rdfDataUnit
+     *            data unit from which all RDF data graphs are obtained
+     * @return {@link Dataset} with defaultGraphs set to all RDF data graphs from the rdfDataUnit
+     * @throws DataUnitException
+     *             when rdfDataUnit does contain any graph or connection errors occur
      */
     public static Dataset getDatasetWithDefaultGraphs(RDFDataUnit rdfDataUnit) throws DataUnitException {
         Set<URI> graphsUriSet = RDFHelper.getGraphsURISet(rdfDataUnit);
@@ -157,4 +207,70 @@ public class RDFHelper {
         }
         return new DatasetBuilder().withDefaultGraphs(graphsUriSet).build();
     }
+
+    /**
+     * Creates new unique RDF data unit entry under the symbolic name being equal to graphName.
+     * 
+     * @param rdfDataUnit
+     * @param graphName
+     * @return new entry
+     * @throws DataUnitException
+     */
+    public static RDFDataUnit.Entry createGraph(WritableRDFDataUnit rdfDataUnit, final String graphName)
+            throws DataUnitException {
+        return RdfDataUnitUtils.addGraph(rdfDataUnit, graphName);
+    }
+
+    /**
+     * Add existing graph with the given graphURI to the rdfDataUnit under the symbolic name equal to graphURI.
+     * 
+     * @param rdfDataUnit
+     * @param graphURI
+     * @return new entry
+     * @throws DataUnitException
+     */
+    public static RDFDataUnit.Entry addGraph(WritableRDFDataUnit rdfDataUnit, URI graphURI)
+            throws DataUnitException {
+        String graphName = graphURI.toString();
+        return RdfDataUnitUtils.addGraph(rdfDataUnit, graphName, graphURI);
+    }
+
+    /**
+     * Add existing graph with the given graphURI to the rdfDataUnit under the symbolic name equal to graphName
+     * 
+     * @param rdfDataUnit
+     * @param graphURI
+     * @param graphName
+     * @return
+     * @throws DataUnitException
+     */
+    public static RDFDataUnit.Entry addGraph(WritableRDFDataUnit rdfDataUnit, URI graphURI, final String graphName)
+            throws DataUnitException {
+        return RdfDataUnitUtils.addGraph(rdfDataUnit, graphName, graphURI);
+    }
+
+    /**
+     * Gets data graph URI of the RDF data unit entry
+     * 
+     * @param entry
+     *            RDF data unit entry
+     * @return data graph URI of the entry
+     * @throws DataUnitException
+     */
+    public static URI asGraph(RDFDataUnit.Entry entry) throws DataUnitException {
+        return RdfDataUnitUtils.asGraph(entry);
+    }
+
+    /**
+     * Gets list of data graph URIs from list of RDF data unit entries
+     * 
+     * @param entries
+     *            List of RDF data unit entries
+     * @return List of data graph URIs of the given entries
+     * @throws DataUnitException
+     */
+    public static URI[] asGraphs(List<RDFDataUnit.Entry> entries) throws DataUnitException {
+        return RdfDataUnitUtils.asGraphs(entries);
+    }
+
 }

--- a/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/rdf/RdfDataUnitUtils.java
+++ b/uv-dataunit-helpers/src/main/java/eu/unifiedviews/helpers/dataunit/rdf/RdfDataUnitUtils.java
@@ -25,8 +25,8 @@ import eu.unifiedviews.dataunit.rdf.RDFDataUnit;
 import eu.unifiedviews.dataunit.rdf.WritableRDFDataUnit;
 
 /**
- * Helper for {@link RDFDataUnit}.
- *
+ * Utils for working with {@link RDFDataUnit}. DPU developer should NOT use this class directly - he should use {@link RDFHelper}.
+ * 
  * @author Škoda Petr
  */
 public class RdfDataUnitUtils {
@@ -37,7 +37,7 @@ public class RdfDataUnitUtils {
     public static class InMemoryEntry implements RDFDataUnit.Entry {
 
         private final URI graphUri;
-                
+
         private final String symbolicName;
 
         public InMemoryEntry(URI graphUri, String symbolicName) {
@@ -54,16 +54,16 @@ public class RdfDataUnitUtils {
         public String getSymbolicName() throws DataUnitException {
             return symbolicName;
         }
-        
+
     }
 
     private RdfDataUnitUtils() {
-        
+
     }
 
     /**
      * Add entry with generated graph name.
-     *
+     * 
      * @param dataUnit
      * @param symbolicName
      * @return Wrap of a new entry.
@@ -82,16 +82,15 @@ public class RdfDataUnitUtils {
      * @param symbolicName
      * @param uri
      * @return Wrap of a new entry.
-     * @throws DataUnitException 
+     * @throws DataUnitException
      */
-    public static InMemoryEntry addGraph(WritableRDFDataUnit dataUnit,String symbolicName, URI uri)
+    public static InMemoryEntry addGraph(WritableRDFDataUnit dataUnit, String symbolicName, URI uri)
             throws DataUnitException {
         dataUnit.addExistingDataGraph(symbolicName, uri);
         return new InMemoryEntry(uri, symbolicName);
     }
 
     /**
-     *
      * @param entry
      * @return URI of graph represented by this entry.
      * @throws DataUnitException
@@ -102,16 +101,16 @@ public class RdfDataUnitUtils {
 
     /**
      * Convert RDF graph entries into their respective URIs.
-     *
+     * 
      * @param entries
      * @return
      * @throws DataUnitException
      */
     public static URI[] asGraphs(List<RDFDataUnit.Entry> entries) throws DataUnitException {
-        final List<URI> result = new ArrayList<>(entries.size());        
+        final List<URI> result = new ArrayList<>(entries.size());
         for (RDFDataUnit.Entry entry : entries) {
             result.add(asGraph(entry));
-        }   
+        }
         return result.toArray(new URI[0]);
     }
 


### PR DESCRIPTION
So far, helper methods were for files data units were in two separate classes. Similarly for rdf data units. This should be unified to simplify life of DPU developer. 

Related material: https://grips.semantic-web.at/display/UDDOC/Tutorial%3A+Working+with+Files+data+units
